### PR TITLE
fix(react-emotion-theme): resolve a bundle issue

### DIFF
--- a/.yarn/versions/25d57a92.yml
+++ b/.yarn/versions/25d57a92.yml
@@ -1,0 +1,5 @@
+releases:
+  design-system: prerelease
+
+undecided:
+  - "@karrotmarket/react-emotion-theme"

--- a/.yarn/versions/25d57a92.yml
+++ b/.yarn/versions/25d57a92.yml
@@ -1,5 +1,5 @@
 releases:
-  design-system: prerelease
+  "@karrotmarket/react-emotion-theme": prerelease
 
-undecided:
-  - "@karrotmarket/react-emotion-theme"
+declined:
+  - design-system

--- a/packages/react-emotion-theme/src/KarrotThemeProvider.tsx
+++ b/packages/react-emotion-theme/src/KarrotThemeProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import useDarkMode from 'use-dark-mode';
-import { css, Global, ThemeProvider as EmotionThemeProvider } from '@emotion/react';
+import { Global, ThemeProvider as EmotionThemeProvider } from '@emotion/react';
 import type { ColorScheme, SemanticColorScheme } from '@karrotmarket/design-token';
 import { colors, populateSemanticColors } from '@karrotmarket/design-token';
 import { ThemeStorageContext, DarkModeContext } from '@karrotmarket/react-theming';
@@ -105,11 +105,11 @@ export const KarrotThemeProvider: React.FC<KarrotThemeProviderProps> = ({
     <>
       {/* required for iOS */}
       <Global
-        styles={css`
-          :root {
-            color-scheme: ${availableScheme[mode]};
+        styles={{
+          ':root': {
+            'colorScheme': availableScheme[mode],
           }
-        `}
+        }}
       />
       <DarkModeContext.Provider value={darkMode}>
         <EmotionThemeProvider theme={theme}>


### PR DESCRIPTION
There is an issue when using Emotion's template literal style API
without transform via the Babel plugin

Error:
> You have illegal escape sequence in your template literal, most likely inside content's property value.
> Because you write your CSS inside a JavaScript string you actually have to do double escaping, so for example "content: '\00d7';" should become "content: '\\00d7';".
> You can read more about this here:
> https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#ES2018_revision_of_illegal_escape_sequences

@See https://github.com/emotion-js/emotion/issues/1755

Well, actually, we don't have to use either template liternal API or the
Babel plugin here