### PR TITLE
chore: Update yarn-changeset-action to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: yarn workspaces foreach -t run build
 
       - name: Create Release Pull Request or Publish to npm
-        uses: cometkim/yarn-changeset-action@master
+        uses: cometkim/yarn-changeset-action@v1
         with:
           autoPublish: true
         env:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
-enableImmutableInstalls: false
-
 packageExtensions:
   istanbul-lib-processinfo@*:
     dependencies:


### PR DESCRIPTION
- I have updated yarn-changeset-action to v1

- I removed below redundant line from `.yarnrc.yml` because default value is `false` for this option.

```
enableImmutableInstalls: false
```